### PR TITLE
Rename all roles options and references to permissions to be more clear

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,11 +17,11 @@
 npm install feathers-permissions --save
 ```
 
-> __Important:__ The `feathers-permissions` hook should be used after the `authenticate()` hook by [@feathersjs/authentication](https://docs.feathersjs.com/api/authentication/server.html#authhooksauthenticatestrategies).
+> __Important:__ The `feathers-permissions` hook should be used after the `authenticate()` [hook from @feathersjs/authentication](https://docs.feathersjs.com/api/authentication/hook.html).
 
 ## Simple example
 
-The following example will limit all `messages` service calls to users that has `admin` in their `permissions`:
+The following example will limit all `messages` service calls to users that have `admin` in their `permissions`:
 
 ```js
 const feathers = require('@feathersjs/feathers');
@@ -33,7 +33,7 @@ app.use('/messages', memory());
 
 app.service('messages').hooks({
   before: checkPermissions({
-    roles: [ 'admin' ]
+    permissions: [ 'admin' ]
   })
 });
 
@@ -42,6 +42,92 @@ const user = {
   email: 'someuser@example.com',
   permissions: [ 'admin' ]
 }
+```
+
+## Documentation
+
+Feathers permissions allows you to grant and manage permissions in a flexible nature. Each object that requires permissions must have an array or a comma separated string of permissions stored on it (typically in your database).
+
+### Options
+
+The following options are available:
+
+- `permissions` - A list of permissions to check or a function that takes the hook `context` and returns a list of permissions. Can be a comma separated string of permissions or an array of permissions.
+- `entity` (default: `user`) - The name of the entity (`params[entity]`)
+- `field` (default: `permissions`) - The name of the permissions field. May be dot separated to access nested fields.
+- `error` - If set to `false` will not throw a `Forbidden` error but instead set `params.permitted` to `true` or `false`. Useful for chaining permission hooks.
+
+### Permission format
+
+The list of permissions will be obtained from `params[entity][field]`. It can be a comma separate list or an array of permissions in the following format:
+
+- `*` - Allow everything
+- `${permission}` or `${permission}:*` - Allow every service method (`find`, `get`, `create`, `update`, `patch`, `remove`) for `permission`
+- `*:${method}` - Allow `method` service method for any permission
+- `${permission}:${method}` - Allow `method` service method for `permission`
+
+This means the following use of `feathers-permissions`:
+
+```js
+app.service('messages').hooks({
+  before: checkPermissions({
+    permissions: [ 'admin', 'user' ]
+  })
+});
+```
+
+Will allow user `permissions` containing `*`, `admin:*`, `user:*` and the service method that is being called (e.g. `admin:create` or `user:find` and `*:create` and `*:find`).
+
+The following will create a dynamic permission based on the hook [`context.path`](https://docs.feathersjs.com/api/hooks.html#contextpath):
+
+```js
+app.service('messages').hooks({
+  before: checkPermissions({
+    permissions: context => {
+      return [ 'admin', context.path ];
+    }
+  })
+});
+```
+
+Permissions can also be assembled asynchronously:
+
+```js
+app.service('messages').hooks({
+  before: checkPermissions({
+    permissions: async context => {
+      const { user } = context.params;
+      const roles = await app.service('roles').find({
+        query: {
+          userId: user._id
+        }
+      });
+
+      return roles.data;
+    }
+  })
+});
+```
+
+### Conditionally restricting permissions
+
+To conditionally either allow access by permission or otherwise restrict to the current user, a combination of `feathers-permissions` - setting the `error` option to `false` - [feathers-authentication-hooks](https://github.com/feathersjs-ecosystem/feathers-authentication-hooks) and [feathers-hooks-common#iff](https://feathers-plus.github.io/v1/feathers-hooks-common/#iff) (checking for `params.permitted`) can be used:
+
+```js
+app.service('messages').hooks({
+  before: {
+    find: [
+      checkPermissions({
+        permissions: ['super_admin', 'admin'],
+        field: 'roles',
+        error: false
+      }),
+      iff(context => !context.params.permitted,
+        restrictToOwner({ idField: '_id', ownerField: '_id'})
+      )
+    ]
+  }
+});
 ```
 
 ## More examples
@@ -56,7 +142,7 @@ app.use('/messages', memory());
 
 app.service('messages').hooks({
   before: checkPermissions({
-    roles: [ 'admin', 'messages' ]
+    permissions: [ 'admin', 'messages' ]
   })
 });
 
@@ -92,94 +178,8 @@ app.service('messages').create({
 });
 ```
 
-## Documentation
-
-Feathers permissions allows you to grant and manage permissions in a flexible nature. Each object that requires permissions must have an array or a comma separated string of permissions stored on it (typically in your database).
-
-### Options
-
-The following options are available:
-
-- `roles` - A list of roles to check or a function that takes the hook `context` and returns a list of roles
-- `entity` (default: `user`) - The name of the entity (`params[entity]`)
-- `field` (default: `permissions`) - The name of the permissions field. Can be a comma separated string of permissions or an array or permissions.
-- `error` - If set to `false` will not throw a `Forbidden` error but instead set `params.permitted` to `true` or `false`. Useful for chaining permission hooks.
-
-### Permission format
-
-The list of permissions will be obtained from `params[entity][field]`. It can be a comma separate list or an array of permissions in the following format:
-
-- `*` - Allow everything
-- `${role}` or `${role}:*` - Allow every service method (`find`, `get`, `create`, `update`, `patch`, `remove`) for `role`
-- `*:${method}` - Allow `method` service method for any role
-- `${role}:${method}` - Allow `method` service method for `role`
-
-This means the following use of `feathers-permissions`:
-
-```js
-app.service('messages').hooks({
-  before: checkPermissions({
-    roles: [ 'admin', 'user' ]
-  })
-});
-```
-
-Will allow user `permissions` containing `*`, `admin:*`, `user:*` and the service method that is being called (e.g. `admin:create` or `user:find` and `*:create` and `*:find`).
-
-The following will create a dynamic role based on the hook [`context.path`](https://docs.feathersjs.com/api/hooks.html#contextpath):
-
-```js
-app.service('messages').hooks({
-  before: checkPermissions({
-    roles(context) {
-      return [ 'admin', context.path ];
-    }
-  })
-});
-```
-
-Roles can also be assembled asynchronously:
-
-```js
-app.service('messages').hooks({
-  before: checkPermissions({
-    async roles(context) {
-      const { user } = context.params;
-      const roles = await app.service('roles').find({
-        query: {
-          userId: user._id
-        }
-      });
-
-      return roles.data;
-    }
-  })
-});
-```
-
-### Conditionally restricting roles
-
-To conditionally either allow access by permission or otherwise restrict to the current user, a combination of `feathers-permissions` - setting the `error` option to `false` - [feathers-authentication-hooks](https://github.com/feathersjs-ecosystem/feathers-authentication-hooks) and [feathers-hooks-common#iff](https://feathers-plus.github.io/v1/feathers-hooks-common/#iff) (checking for `params.permitted`) can be used:
-
-```js
-app.service('messages').hooks({
-  before: {
-    find: [
-      checkPermissions({
-        roles: ['super_admin', 'admin'],
-        field: 'role',
-        error: false
-      }),
-      iff(context => !context.params.permitted,
-        restrictToOwner({ idField: '_id', ownerField: '_id'})
-      )
-    ]
-  }
-});
-```
-
 ## License
 
-Copyright (c) 2018
+Copyright (c) 2019
 
 Licensed under the [MIT license](LICENSE).

--- a/lib/index.js
+++ b/lib/index.js
@@ -3,25 +3,27 @@ const get = require('lodash/get');
 
 const debug = require('debug')('feathers-permissions');
 
-module.exports = function checkPermissions ({
-  entity: entityName = 'user',
-  field = 'permissions',
-  error = true,
-  roles
-} = {}) {
-  if (!Array.isArray(roles) && typeof roles !== 'function') {
+module.exports = function checkPermissions (options = {}) {
+  const {
+    entity: entityName = 'user',
+    field = 'permissions',
+    error = true
+  } = options;
+  const permissions = options.permissions || options.roles;
+
+  if (!Array.isArray(permissions) && typeof permissions !== 'function') {
     throw new Error('\'roles\' option for feathers-permissions hook must be an array or a function');
   }
 
   return async context => {
     const { params, type, method } = context;
-    const currentRoles = await Promise.resolve(typeof roles === 'function' ? roles(context) : roles);
+    const currentPermissions = await Promise.resolve(typeof permissions === 'function' ? permissions(context) : permissions);
 
     if (type !== 'before') {
       throw new Error('The feathers-permissions hook should only be used as a \'before\' hook.');
     }
 
-    debug('Running checkPermissions hook with options:', { entityName, field, roles });
+    debug('Running checkPermissions hook with options:', { entityName, field, roles: permissions });
 
     const entity = context.params[entityName];
 
@@ -37,24 +39,22 @@ module.exports = function checkPermissions ({
 
     // Normalize permissions. They can either be a comma separated string or an array.
     const value = get(entity, field, []);
-    const permissions = typeof value === 'string'
+    const permissionList = typeof value === 'string'
       ? value.split(',').map(current => current.trim()) : value;
     const requiredPermissions = [
       '*',
       `*:${method}`
     ];
 
-    currentRoles.forEach(role => {
-      requiredPermissions.push(
-        `${role}`,
-        `${role}:*`,
-        `${role}:${method}`
-      );
-    });
+    currentPermissions.forEach(permission => requiredPermissions.push(
+      `${permission}`,
+      `${permission}:*`,
+      `${permission}:${method}`
+    ));
 
     debug('Required Permissions', requiredPermissions);
 
-    const permitted = permissions.some(permission => requiredPermissions.includes(permission));
+    const permitted = permissionList.some(current => requiredPermissions.includes(current));
 
     context.params = {
       permitted,

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -21,7 +21,7 @@ describe('feathers-permissions integration tests', () => {
 
       app.service('messages').hooks({
         before: checkPermissions({
-          roles: ['messages', 'admin']
+          permissions: ['messages', 'admin']
         })
       });
     });


### PR DESCRIPTION
"Roles" doesn't really make a lot of sense here and calling everything "Permissions" should make things more clear.