### PR TITLE
Rename option back to roles

### DIFF
--- a/test/index.test.js
+++ b/test/index.test.js
@@ -21,7 +21,7 @@ describe('feathers-permissions integration tests', () => {
 
       app.service('messages').hooks({
         before: checkPermissions({
-          permissions: ['messages', 'admin']
+          roles: ['messages', 'admin']
         })
       });
     });

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -5,7 +5,7 @@ export interface PermissionOptions {
   error?: boolean;
   entity?: string;
   field?: string;
-  permissions: string|string[];
+  roles: string|string[];
 }
 
 declare const checkPermissions: ((options?: PermissionOptions) => Hook);

--- a/types/index.test.ts
+++ b/types/index.test.ts
@@ -11,6 +11,6 @@ app.use('/dummy', {
 
 app.service('dummy').hooks({
   before: checkPermissions({
-    permissions: [ 'admin' ]
+    roles: [ 'admin' ]
   })
 });


### PR DESCRIPTION
This was a mistake and shouldn't cause too many problems since it was backwards compatible anyway.