### PR TITLE
Always error when entity is available but does not have permissions

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,13 +163,11 @@ const admin = {
 
 // Will pass
 app.service('messages').find({
-  provider: 'rest', // this will be set automatically by external calls
   user
 });
 
 // Will fail
 app.service('messages').create({
-  provider: 'rest', // this will be set automatically by external calls
   user
 });
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -56,14 +56,14 @@ module.exports = function checkPermissions (options = {}) {
 
     const permitted = permissionList.some(current => requiredPermissions.includes(current));
 
+    if (error !== false && !permitted) {
+      throw new Forbidden('You do not have the correct permissions.');
+    }
+
     context.params = {
       permitted,
       ...params
     };
-
-    if (context.params.provider && error !== false && !context.params.permitted) {
-      throw new Forbidden('You do not have the correct permissions.');
-    }
 
     return context;
   };


### PR DESCRIPTION
This is a breaking change in that it will now always throw an error if the entity (`params.user`) is available but does not have the correct permission. Previously this only happened on external requests.

This change makes it easier to write tests and removes some hidden magic. If a pass-through is required, the `error` option can be set as before.

Also increases code coverage to 100%.